### PR TITLE
Fixes homepage title, preserves it during pagination

### DIFF
--- a/templates/_layouts/default.twig
+++ b/templates/_layouts/default.twig
@@ -1,4 +1,5 @@
 {% set global = craft.entries.section('global').one() %}
+{% set pageTitle = pageTitle ?? entry.title ?? siteName %}
 
 <!DOCTYPE html>
 <html lang="en-US">
@@ -12,7 +13,7 @@
   <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
   <link rel="manifest" href="/manifest.webmanifest" />
   <meta charset="utf-8" />
-  <title>{% if entry is defined %}{{ entry.title }}{% endif %}{% block title %}{% endblock %} | {{ siteName }}</title>
+  <title>{% block title %}{{ pageTitle }}{% endblock %}{% if pageTitle != siteName %} | {{ siteName }}{% endif %}</title>
   <meta name="referrer" content="origin-when-cross-origin" />
 
   {# Include Tailwind Play CDN for basic styling #}

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -1,3 +1,3 @@
-{% block title 'Home' %}
+{% set pageTitle = 'Home' %}
 
 {% extends "pages/blog" %}

--- a/templates/pages/blog.twig
+++ b/templates/pages/blog.twig
@@ -7,9 +7,11 @@
 {% paginate postQuery as pageInfo, posts %}
 
 {% block title %}
-  {% if pageInfo.getPrevUrl() or pageInfo.getNextUrl() %}
-  , Page {{ pageInfo.currentPage }} of {{ pageInfo.totalPages }}
-  {% endif %}
+  {{ parent() }}
+  {%- if pageInfo.currentPage > 1 -%}
+    {%- if pageInfo.getPrevUrl() or pageInfo.getNextUrl() %}, Page {{ pageInfo.currentPage }} of {{ pageInfo.totalPages }}
+    {% endif %}
+  {%- endif -%}
 {% endblock %}
 
 {% block landing %}


### PR DESCRIPTION
### Description

I’m seeing both the entry title and the static template title showing up on the homepage as the `<title>`, ex. “HomeHome.” I believe the pagination suffix also wasn’t showing up as expected due to the hard-coded title for fresh installs.

This is one way we could fix it. It was working for me with existing content, and with no homepage, like on a fresh install.
